### PR TITLE
hasRoleOrRestrict should call find with a single, merged parameter

### DIFF
--- a/src/has-role-or-restrict.js
+++ b/src/has-role-or-restrict.js
@@ -53,7 +53,7 @@ export default function (options = {}) {
         return hook;
       }
 
-      return hook.service.find({ query }, params).then(results => {
+      return hook.service.find(Object.assign({}, params, { query })).then(results => {
         if (hook.method === 'get' && Array.isArray(results) && results.length === 1) {
           hook.result = results[0];
           return hook;
@@ -131,7 +131,7 @@ export default function (options = {}) {
         return hook;
       }
 
-      return hook.service.find({ query }, params).then(results => {
+      return hook.service.find(Object.assign({}, params, { query })).then(results => {
         if (hook.method === 'get' && Array.isArray(results) && results.length === 1) {
           hook.result = results[0];
           return hook;

--- a/test/has-role-or-restrict.test.js
+++ b/test/has-role-or-restrict.test.js
@@ -93,7 +93,7 @@ describe('hasRoleOrRestrict', () => {
       };
 
       hasRoleOrRestrict({ roles: ['admin'], restrict: {approved: true} }).call(mockService, hook);
-      expect(mockFind).to.be.calledWith({ query: {author: 'James', approved: true} }, { provider: undefined, query: { author: 'James' } });
+      expect(mockFind).to.be.calledWith({ provider: undefined, query: {author: 'James', approved: true} });
     });
 
     it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
@@ -111,7 +111,7 @@ describe('hasRoleOrRestrict', () => {
       };
 
       hasRoleOrRestrict({roles: ['admin'], restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
-      expect(mockFind).to.be.calledWith({ query: {'_id': '525235', approved: true} }, { provider: undefined });
+      expect(mockFind).to.be.calledWith({ provider: undefined, query: {'_id': '525235', approved: true} });
     });
   });
 
@@ -184,7 +184,7 @@ describe('hasRoleOrRestrict', () => {
         };
 
         hasRoleOrRestrict({ roles: ['admin'], restrict: {approved: true} }).call(mockService, hook);
-        expect(mockFind).to.be.calledWith({ query: {author: 'James', approved: true} }, { provider: undefined, query: { author: 'James' } });
+        expect(mockFind).to.be.calledWith({ provider: undefined, query: {author: 'James', approved: true} });
       });
 
       it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
@@ -202,7 +202,7 @@ describe('hasRoleOrRestrict', () => {
         };
 
         hasRoleOrRestrict({roles: ['admin'], restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
-        expect(mockFind).to.be.calledWith({ query: {'_id': '525235', approved: true} }, { provider: undefined });
+        expect(mockFind).to.be.calledWith({ provider: undefined, query: {'_id': '525235', approved: true} });
       });
 
       describe('when owner option enabled', () => {


### PR DESCRIPTION
Fix for #41 

hasRoleOrRestrict should call find with a single, merged parameter. There is a validation on Feathers Buzzard that breaks this hook because there are 2 parameters.

As stated by @daffl, this probably never worked as intended.