### PR TITLE
allow array in typescript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ import { Hook } from '@feathersjs/feathers';
 
 export interface HookOptions {
   from: string;
-  as: string | Array<string>;
+  as: string | string[];
   allowUndefined?: boolean;
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ import { Hook } from '@feathersjs/feathers';
 
 export interface HookOptions {
   from: string;
-  as: string;
+  as: string | Array<string>;
   allowUndefined?: boolean;
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 import { Hook } from '@feathersjs/feathers';
 
 export interface HookOptions {
-  from: string;
+  from: string | string[];
   as: string | string[];
   allowUndefined?: boolean;
 }


### PR DESCRIPTION
### Summary

Documentation allows for the `as` paramater to be an array or a string. The typescript typing is currently set to `string`. This PR changes the `as` paramater to type `string | Array<string>`.